### PR TITLE
Changes node-sass dependency version range

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "image-size": "^0.3.5",
     "mime": "^1.3.4",
-    "node-sass": "^3.2.0"
+    "node-sass": ">= 3.2 < 5"
   },
   "devDependencies": {
     "jest": "^16.0.2"


### PR DESCRIPTION
When `node-sass` is restricted to version 3, projects that use the `node-sass-asset-functions` module are also restricted to `node-sass` version 3. This pull request makes it possible to use `node-sass-asset-functions` with `node-sass` version 4.

I'm not sure how else to handle this. It would be nice if NPM provided a better way to manage these types of peer dependencies...