### PR TITLE
Make Sass implementation agnostic ( supporting dart-sass )

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Node SASS Asset functions [![Build Status](https://travis-ci.org/fetch/node-sass-asset-functions.svg?branch=master)](https://travis-ci.org/fetch/node-sass-asset-functions) [![npmjs](https://badge.fury.io/js/node-sass-asset-functions.svg)](https://www.npmjs.com/package/node-sass-asset-functions)
 
-To ease the transitioning from Compass to Libsass, this module provides some of Compass' asset functions for [node-sass](https://github.com/sass/node-sass)
+To ease the transitioning from Compass to Libsass, this module provides some of Compass' asset functions for [node-sass](https://github.com/sass/node-sass) or [sass](https://github.com/sass/sass)
 
 _**NB** Please note that the `functions` option of node-sass is still experimental (>= v3.0.0)._
 
@@ -80,6 +80,24 @@ sass.render({
     asset_cache_buster: function(http_path, real_path, done){
       done('v=123');
     }
+  }),
+  file: scss_filename,
+  [, options..]
+}, function(err, result) { /*...*/ });
+```
+
+#### `implementation`: a function to switch sass implementation
+
+If you like to use other sass implementation (like `sass`), you can use `implementation` option to pass the module.
+
+When you omit `implementation` option, `node-sass` ( version `^4.9.3` ) is implicitly used. ( See `devDependencies` of [package.json](https://github.com/fetch/node-sass-asset-functions/blob/master/package.json) )
+
+```js
+var sass = require('sass')
+
+sass.render({
+  functions: assetFunctions({
+    implementation: sass,
   }),
   file: scss_filename,
   [, options..]

--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -1,21 +1,20 @@
 var fs = require('fs')
 var path = require('path')
-var sass = require('node-sass')
 var assetFunctions = require('../')
 
-var renderAsync = function(file, options, done) {
+var renderAsync = function(sass, file, options, done) {
   options = options || {}
   options.images_path = __dirname + '/images'
   options.fonts_path = __dirname + '/fonts'
 
   return sass.render({
-    functions: assetFunctions(options),
+    functions: assetFunctions(options, sass),
     file: __dirname + '/scss/' + file
   }, done)
 }
 
-var equalsFileAsync = function(file, suite, options, done) {
-  renderAsync(file, options, function(err, result) {
+var equalsFileAsync = function(sass, file, suite, options, done) {
+  renderAsync(sass, file, options, function(err, result) {
     expect(err).toBeNull()
     var cssPath = path.join(cssDir, suite, file.replace(/\.scss$/, '.css'))
     fs.readFile(cssPath, function(err, expected) {
@@ -44,42 +43,46 @@ var path_asset_cache_buster = function(http_path, real_path, done) {
     var extname = path.extname(http_path)
       , basename = path.basename(http_path, extname)
       , dirname = path.dirname(http_path)
-    
+
     done({path: path.join(dirname, basename + '-v123') + extname, query: null})
   }, 10)
 }
 
 var files = fs.readdirSync(sassDir)
 
-describe('basic', function() {
-  files.forEach(function(file) {
-    test(file, function(done) {
-      equalsFileAsync(file, 'basic', {}, done)
-    })
-  })
-})
+describe.each(['node-sass', 'sass'])('with require("%s")', function(module) {
+  var impl = require(module)
 
-describe('asset_host', function() {
-  files.forEach(function(file) {
-    test(file, function(done) {
-      equalsFileAsync(file, 'asset_host', { asset_host: asset_host }, done)
-    })
-  })
-})
-
-describe('asset_cache_buster', function() {
-  describe('using query', function() {
+  describe('basic', function() {
     files.forEach(function(file) {
       test(file, function(done) {
-        equalsFileAsync(file, 'asset_cache_buster/query', { asset_cache_buster: query_asset_cache_buster }, done)
+        equalsFileAsync(impl, file, 'basic', {}, done)
       })
     })
   })
 
-  describe('using path', function() {
+  describe('asset_host', function() {
     files.forEach(function(file) {
       test(file, function(done) {
-        equalsFileAsync(file, 'asset_cache_buster/path', { asset_cache_buster: path_asset_cache_buster }, done)
+        equalsFileAsync(impl, file, 'asset_host', { asset_host: asset_host }, done)
+      })
+    })
+  })
+
+  describe('asset_cache_buster', function() {
+    describe('using query', function() {
+      files.forEach(function(file) {
+        test(file, function(done) {
+          equalsFileAsync(impl, file, 'asset_cache_buster/query', { asset_cache_buster: query_asset_cache_buster }, done)
+        })
+      })
+    })
+
+    describe('using path', function() {
+      files.forEach(function(file) {
+        test(file, function(done) {
+          equalsFileAsync(impl, file, 'asset_cache_buster/path', { asset_cache_buster: path_asset_cache_buster }, done)
+        })
       })
     })
   })

--- a/__tests__/test.js
+++ b/__tests__/test.js
@@ -6,10 +6,11 @@ var renderAsync = function(sass, file, options, done) {
   options = options || {}
   options.images_path = __dirname + '/images'
   options.fonts_path = __dirname + '/fonts'
+  options.implemantation = sass
 
   return sass.render({
-    functions: assetFunctions(options, sass),
-    file: __dirname + '/scss/' + file
+    functions: assetFunctions(options),
+    file: __dirname + '/scss/' + file,
   }, done)
 }
 
@@ -50,13 +51,13 @@ var path_asset_cache_buster = function(http_path, real_path, done) {
 
 var files = fs.readdirSync(sassDir)
 
-describe.each(['node-sass', 'sass'])('with require("%s")', function(module) {
-  var impl = require(module)
+describe.each(['node-sass', 'sass'])('with require("%s")', function(impl) {
+  var sass = require(impl)
 
   describe('basic', function() {
     files.forEach(function(file) {
       test(file, function(done) {
-        equalsFileAsync(impl, file, 'basic', {}, done)
+        equalsFileAsync(sass, file, 'basic', {}, done)
       })
     })
   })
@@ -64,7 +65,7 @@ describe.each(['node-sass', 'sass'])('with require("%s")', function(module) {
   describe('asset_host', function() {
     files.forEach(function(file) {
       test(file, function(done) {
-        equalsFileAsync(impl, file, 'asset_host', { asset_host: asset_host }, done)
+        equalsFileAsync(sass, file, 'asset_host', { asset_host: asset_host }, done)
       })
     })
   })
@@ -73,7 +74,7 @@ describe.each(['node-sass', 'sass'])('with require("%s")', function(module) {
     describe('using query', function() {
       files.forEach(function(file) {
         test(file, function(done) {
-          equalsFileAsync(impl, file, 'asset_cache_buster/query', { asset_cache_buster: query_asset_cache_buster }, done)
+          equalsFileAsync(sass, file, 'asset_cache_buster/query', { asset_cache_buster: query_asset_cache_buster }, done)
         })
       })
     })
@@ -81,7 +82,7 @@ describe.each(['node-sass', 'sass'])('with require("%s")', function(module) {
     describe('using path', function() {
       files.forEach(function(file) {
         test(file, function(done) {
-          equalsFileAsync(impl, file, 'asset_cache_buster/path', { asset_cache_buster: path_asset_cache_buster }, done)
+          equalsFileAsync(sass, file, 'asset_cache_buster/path', { asset_cache_buster: path_asset_cache_buster }, done)
         })
       })
     })

--- a/index.js
+++ b/index.js
@@ -1,9 +1,18 @@
 var Processor = require('./lib/processor');
 
-module.exports = function(options, impl) {
+function omit(original, omitted) {
+  return Object.keys(original).reduce(function (result, key) {
+    if (key !== omitted) {
+      result[key] = original[key];
+    }
+    return result;
+  }, {});
+}
+
+module.exports = function(options) {
   var opts = options || {};
-  var processor = new Processor(opts);
-  var sass = impl || require('node-sass')
+  var processor = new Processor(omit(opts, 'implementation'));
+  var sass = opts.implementation || require('node-sass')
 
   return {
     'image-url($filename, $only_path: false)': function(filename, only_path, done) {

--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
-var sass = require('node-sass');
 var Processor = require('./lib/processor');
 
-module.exports = function(options) {
+module.exports = function(options, impl) {
   var opts = options || {};
   var processor = new Processor(opts);
+  var sass = impl || require('node-sass')
 
   return {
     'image-url($filename, $only_path: false)': function(filename, only_path, done) {

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
   "homepage": "https://github.com/fetch/node-sass-asset-functions",
   "dependencies": {
     "image-size": "^0.3.5",
-    "mime": "^1.3.4",
+    "mime": "^1.3.4"
+  },
+  "optionalDependencies": {
     "node-sass": ">= 3.2 < 5"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -31,10 +31,9 @@
     "image-size": "^0.3.5",
     "mime": "^1.3.4"
   },
-  "optionalDependencies": {
-    "node-sass": ">= 3.2 < 5"
-  },
   "devDependencies": {
-    "jest": "^16.0.2"
+    "jest": "^23.6.0",
+    "node-sass": "^4.9.3",
+    "sass": "^1.13.4"
   }
 }


### PR DESCRIPTION
Resolves: https://github.com/fetch/node-sass-asset-functions/issues/16

------

I made this library to be sass-implementation agnostic, that means, add support for `dart-sass`.

With these changes, node-sass-asset-functions now accepts `implementation` option ( which excepts `require('node-sass')` or `require('sass')`, and when absent it will be implicitly `node-sass` )

------

For some reason the test is not passing ( Maybe `dart-sass` cannot read file correctly, even though the path looks correct ), which is now I'm searching why... Help wanted by someone.

