### PR TITLE
Relax node sass dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "image-size": "^0.3.5",
     "mime": "^1.3.4",
-    "node-sass": ">= 3.2 < 5"
+    "node-sass": ">= 3.2"
   },
   "devDependencies": {
     "jest": "^16.0.2"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/fetch/node-sass-asset-functions.git"
+    "url": "https://github.com/mycase/node-sass-asset-functions.git"
   },
   "keywords": [
     "node",
@@ -21,15 +21,15 @@
     "font-url",
     "font-files"
   ],
-  "author": "Koen Punt <koen@fetch.nl>",
+  "author": "MyCase, Inc.",
   "license": "MIT",
   "publishConfig": {
     "registry": "https://npm.pkg.github.com/"
   },
   "bugs": {
-    "url": "https://github.com/fetch/node-sass-asset-functions/issues"
+    "url": "https://github.com/mycase/node-sass-asset-functions/issues"
   },
-  "homepage": "https://github.com/fetch/node-sass-asset-functions",
+  "homepage": "https://github.com/mycase/node-sass-asset-functions",
   "dependencies": {
     "image-size": "^0.3.5",
     "mime": "^1.3.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "node-sass-asset-functions",
-  "version": "0.1.0",
+  "name": "@mycase/node-sass-asset-functions",
+  "version": "0.2.0",
   "description": "asset functions for node-sass",
   "main": "index.js",
   "scripts": {
@@ -23,6 +23,9 @@
   ],
   "author": "Koen Punt <koen@fetch.nl>",
   "license": "MIT",
+  "publishConfig": {
+    "registry": "https://npm.pkg.github.com/"
+  },
   "bugs": {
     "url": "https://github.com/fetch/node-sass-asset-functions/issues"
   },


### PR DESCRIPTION
Relax node sass dependency for node 16, and enable package publishing to npm.